### PR TITLE
Export coverage report as xml

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ commands =
     - py.test tests
     - coverage run --source commandlines -m py.test
     - coverage report
+    - coverage xml
 deps =
     pytest
     coverage


### PR DESCRIPTION
Need to export the report as xml for Codecov. 

> I think this will will fix the issues, otherwise I'll look into other options. Thanks
